### PR TITLE
Fix capture groups

### DIFF
--- a/lib/image_resizer/image.rb
+++ b/lib/image_resizer/image.rb
@@ -53,7 +53,7 @@ module ImageResizer
     # http://foo/http://bar.jpg -> http://bar.jpg
     # Adds the media domain if it is missing, since ReSRC.it expects a full URL
     def full_url
-      tokens = @url.split(%r{((http(s)?:)?//)})
+      tokens = @url.split(%r{((https?:)?//)})
       if tokens.size == 1
         # foo.jpg => //mediadomain/foo.jpg
         (domain = ImageResizer.media_domain) ? "#{domain}/#{url.gsub(/^\//, '')}" : url

--- a/spec/lib/image_resizer/image_spec.rb
+++ b/spec/lib/image_resizer/image_spec.rb
@@ -26,9 +26,9 @@ module ImageResizer
       end
 
       it 'prevents double ReSRC.it URLs' do
-        item = described_class.new('http://resrc.it/foobar/http://foo.jpg')
+        item = described_class.new('http://resrc.it/foobar/https://foo.jpg')
         output = item.optimize(quality: 50).to_url
-        expect(output).to eq('https://images-resrc.staticlp.com/O=50/http://foo.jpg')
+        expect(output).to eq('https://images-resrc.staticlp.com/O=50/https://foo.jpg')
       end
     end
 


### PR DESCRIPTION
The previous capture group did not work as expected whenthe source url used HTTPS. It would collect too many captures

This shows the difference between the two:

```ruby
@url = "https://example.com/image"
@url.split(%r{((http(s)?:)?//)})
  #> ["", "https://", "https:", "s", "example.com/image"]

@url.split(%r{((https?:)?//)})
  #> ["", "http:", "example.com/image"]
```

"https://example.com/image".split(%r{((http(s)?:)?//)})